### PR TITLE
Fix filesystem path creation for nested directories

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -75,7 +75,7 @@ class Image
 
 	public function getPath()
 	{
-		return implode('/', [dirname($this->data_path), $this->createLink()]);
+		return implode('/', [$this->data_path, $this->identifier]);
 	}
 
 

--- a/tests/cases/ImageTest.phpt
+++ b/tests/cases/ImageTest.phpt
@@ -1,0 +1,40 @@
+<?php
+
+namespace Ublaboo\Mailing\Tests\Cases;
+
+use Tester\Assert;
+use Tester\TestCase;
+use Ublaboo\ImageStorage\Image;
+
+require __DIR__ . '/../bootstrap.php';
+
+final class ImageTest extends TestCase
+{
+
+	public function testGetPath()
+	{
+		$image = new Image(false, '', '/data', 'namespace/47/img.jpg');
+		Assert::equal('/data/namespace/47/img.jpg', $image->getPath());
+	}
+
+	public function testGetPathNested()
+	{
+		$image = new Image(false, '', '/data/images', 'namespace/47/img.jpg');
+		Assert::equal('/data/images/namespace/47/img.jpg', $image->getPath());
+	}
+
+	public function testCreateLink()
+	{
+		$image = new Image(false, 'data', '', 'namespace/47/img.jpg');
+		Assert::equal('data/namespace/47/img.jpg', $image->createLink());
+	}
+
+	public function testCreateLinkNested()
+	{
+		$image = new Image(false, 'data/images', '', 'namespace/47/img.jpg');
+		Assert::equal('data/images/namespace/47/img.jpg', $image->createLink());
+	}
+}
+
+$test_case = new ImageTest();
+$test_case->run();


### PR DESCRIPTION
Hi, 
thanks for this library.

This configuration
```
imageStorage:
	data_path          : %wwwDir%/data/images # Filesystem location
	data_dir           : data/images                    # Relative path
```
causes wrong filesystem path creation. Function
```
$image->getPath()
```
returns
```
 %wwwDir%/data/data/images/...
```
it should return 
```
 %wwwDir%/data/images/...
```
This PR should fix it.



