### PR TITLE
fix: Bad return type in getNoImage() method

### DIFF
--- a/src/ImageStorage.php
+++ b/src/ImageStorage.php
@@ -242,8 +242,9 @@ class ImageStorage
 
 	/**
 	 * @throws ImageStorageException
+	 * @return Image|mixed[]
 	 */
-	public function getNoImage(bool $return_image = false): Image
+	public function getNoImage(bool $return_image = false)
 	{
 		$script = ImageNameScript::fromIdentifier($this->noimage_identifier);
 		$file = implode('/', [$this->data_path, $script->original]);


### PR DESCRIPTION
The method getNoImage can return Contributte\ImageStorage\Image or array.