### PR TITLE
Namespace can contain slashes (subfolders), tests correction

### DIFF
--- a/src/ImageNameScript.php
+++ b/src/ImageNameScript.php
@@ -55,7 +55,7 @@ class ImageNameScript
 
 	public static function fromName(string $name): ImageNameScript
 	{
-		$pattern = preg_replace('/__file__/', '([^\/]*)\/(.*)\/(.*?)', self::PATTERN);
+		$pattern = preg_replace('/__file__/', '(.*)\/([^\/]{2})\/(.*?)', self::PATTERN);
 		preg_match($pattern, $name, $matches);
 
 		$script = new self($matches[0]);

--- a/src/ImageNameScript.php
+++ b/src/ImageNameScript.php
@@ -55,7 +55,7 @@ class ImageNameScript
 
 	public static function fromName(string $name): ImageNameScript
 	{
-		$pattern = preg_replace('/__file__/', '([^\/]*)\/([^\/]*)\/(.*?)', self::PATTERN);
+		$pattern = preg_replace('/__file__/', '([^\/]*)\/(.*)\/(.*?)', self::PATTERN);
 		preg_match($pattern, $name, $matches);
 
 		$script = new self($matches[0]);

--- a/tests/cases/ImageNameScriptTest.php
+++ b/tests/cases/ImageNameScriptTest.php
@@ -13,32 +13,46 @@ final class ImageNameScriptTest extends BaseTestCase
 
 	public function testFromName(): void
 	{
-		$s = ImageNameScript::fromName('/data/images/ed/kitty.100x200.fill.q100.jpg');
+		$s = ImageNameScript::fromName('images/49/kitty.100x200.fill.q100.jpg');
 
-		Assert::same($s->original, '/data/images/ed/kitty.jpg');
-		Assert::same($s->prefix, 'data');
-		Assert::same($s->name, 'images/ed/kitty');
+		Assert::same($s->original, 'images/49/kitty.jpg');
+		Assert::same($s->namespace, 'images');
+		Assert::same($s->prefix, '49');
+		Assert::same($s->name, 'kitty');
 		Assert::same($s->flag, 'fill');
 		Assert::same($s->quality, '100');
 		Assert::same($s->size, [100, 200]);
 		Assert::same($s->extension, 'jpg');
 		Assert::same($s->crop, []);
 
-		$s = ImageNameScript::fromName('/data/images/ed/kitty.200x200crop100x150x100x100.fit.q85.jpg');
+		$s = ImageNameScript::fromName('images/10/20/49/kitty.100x200.fill.q100.jpg');
+
+		Assert::same($s->original, 'images/10/20/49/kitty.jpg');
+		Assert::same($s->namespace, 'images/10/20');
+		Assert::same($s->prefix, '49');
+		Assert::same($s->name, 'kitty');
+		Assert::same($s->flag, 'fill');
+		Assert::same($s->quality, '100');
+		Assert::same($s->size, [100, 200]);
+		Assert::same($s->extension, 'jpg');
+		Assert::same($s->crop, []);
+
+
+		$s = ImageNameScript::fromName('/data/images/49/kitty.200x200crop100x150x100x100.fit.q85.jpg');
 		Assert::same($s->crop, [100, 150, 100, 100]);
 	}
 
 
 	public function testFromIdentifier(): void
 	{
-		$s = ImageNameScript::fromIdentifier('images/ed/kitty.jpg');
+		$s = ImageNameScript::fromIdentifier('images/49/kitty.jpg');
 
 		$s->setQuality(2);
 		$s->setSize([2, 2]);
 		$s->setFlag('exact');
 
-		Assert::same($s->getIdentifier(), 'images/ed/kitty.2x2.exact.q2.jpg');
-		Assert::same($s->toQuery(), 'images/ed/2x2.exact.q2/kitty.jpg?_image_storage');
+		Assert::same($s->getIdentifier(), 'images/49/kitty.2x2.exact.q2.jpg');
+		Assert::same($s->toQuery(), 'images/49/2x2.exact.q2/kitty.jpg?_image_storage');
 	}
 
 }

--- a/tests/cases/ImageNameScriptTest.php
+++ b/tests/cases/ImageNameScriptTest.php
@@ -37,7 +37,6 @@ final class ImageNameScriptTest extends BaseTestCase
 		Assert::same($s->extension, 'jpg');
 		Assert::same($s->crop, []);
 
-
 		$s = ImageNameScript::fromName('/data/images/49/kitty.200x200crop100x150x100x100.fit.q85.jpg');
 		Assert::same($s->crop, [100, 150, 100, 100]);
 	}

--- a/tests/cases/ImageStorageTest.php
+++ b/tests/cases/ImageStorageTest.php
@@ -58,29 +58,40 @@ final class ImageStorageTest extends BaseTestCase
 	public function testDelete(): void
 	{
 		$files = __DIR__ . '/../data/files';
-		@mkdir($files . '/a', 0777, true);
+		@mkdir($files . '/49', 0777, true);
 
 		$file_array = [
-			sprintf('%s/a/kitty.100x100.fit.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.fit.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.exact.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.shrink_only.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.fill.q1.jpg', $files),
-			sprintf('%s/a/kitty.100x200.stretch.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.fill.q10.jpg', $files),
-			sprintf('%s/a/kitty.200x200crop100x150x100x100.fit.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.fill.q100.jpg', $files),
-			sprintf('%s/a/kitty.20x20.fit.q85.jpg', $files),
-			sprintf('%s/a/kitty.100x200.fill.q85.jpg', $files),
-			sprintf('%s/a/kitty.jpg', $files),
+			sprintf('%s/49/kitty.100x100.fit.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.fit.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.exact.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.shrink_only.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.fill.q1.jpg', $files),
+			sprintf('%s/49/kitty.100x200.stretch.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.fill.q10.jpg', $files),
+			sprintf('%s/49/kitty.200x200crop100x150x100x100.fit.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.fill.q100.jpg', $files),
+			sprintf('%s/49/kitty.20x20.fit.q85.jpg', $files),
+			sprintf('%s/49/kitty.100x200.fill.q85.jpg', $files),
+			sprintf('%s/49/kitty.jpg', $files),
 		];
 
 		foreach ($file_array as $name) {
 			touch($name);
 		}
 
-		$this->storage->delete('files/a/kitty.jpg');
+		$this->storage->delete('files/49/kitty.jpg');
 
+		foreach ($file_array as $name) {
+			Assert::falsey(file_exists($name));
+		}
+
+		foreach ($file_array as $name) {
+			touch($name);
+		}
+
+		$this->storage->delete('files/49/kitty.jpg', true);
+
+		array_pop($file_array);
 		foreach ($file_array as $name) {
 			Assert::falsey(file_exists($name));
 		}

--- a/tests/cases/ImageStorageTest.php
+++ b/tests/cases/ImageStorageTest.php
@@ -91,10 +91,12 @@ final class ImageStorageTest extends BaseTestCase
 
 		$this->storage->delete('files/49/kitty.jpg', true);
 
-		array_pop($file_array);
+		$originalImage = array_pop($file_array);
 		foreach ($file_array as $name) {
 			Assert::falsey(file_exists($name));
 		}
+
+		Assert::truthy(file_exists($originalImage));
 	}
 
 


### PR DESCRIPTION
Namespace can contain slashes (subfolders)
e.g.:
<data_dir>/eg/image.jpg (where "eg" is namespace)
<data_dir>/10/20/eg/image.jpg (where "10/20/eg" is namespace)

Tests correction:
- prefix must contain 2 characters
- add new test for deleting only changed images 