### PR TITLE
Resolve #43

### DIFF
--- a/src/ImageNameScript.php
+++ b/src/ImageNameScript.php
@@ -47,7 +47,7 @@ class ImageNameScript
 
 	public static function fromName(string $name): ImageNameScript
 	{
-		$pattern = preg_replace('/__file__/', '(.*)\/([^\/]{2})\/(.*?)', self::PATTERN);
+		$pattern = preg_replace('/__file__/', '(.*)\/([^\/]+)\/(.*?)', self::PATTERN);
 		preg_match($pattern, $name, $matches);
 
 		$script = new self($matches[0]);

--- a/tests/Cases/ImageNameScriptTest.php
+++ b/tests/Cases/ImageNameScriptTest.php
@@ -53,6 +53,41 @@ final class ImageNameScriptTest extends TestCase
 		Assert::same($s->toQuery(), 'images/49/2x2.exact.q2/kitty.jpg?_image_storage');
 	}
 
+	/**
+	 * Test that noimage paths with longer prefix work (issue #43)
+	 */
+	public function testFromNameWithLongerPrefix(): void
+	{
+		// Test noimage path with "noimage" as prefix (7 characters)
+		$s = ImageNameScript::fromName('images/noimage/no-image.png');
+
+		Assert::same($s->original, 'images/noimage/no-image.png');
+		Assert::same($s->namespace, 'images');
+		Assert::same($s->prefix, 'noimage');
+		Assert::same($s->name, 'no-image');
+		Assert::same($s->extension, 'png');
+		Assert::same($s->size, [0, 0]);
+		Assert::same($s->crop, []);
+
+		// Test noimage path without namespace
+		$s = ImageNameScript::fromName('noimage/placeholder/image.jpg');
+
+		Assert::same($s->original, 'noimage/placeholder/image.jpg');
+		Assert::same($s->namespace, 'noimage');
+		Assert::same($s->prefix, 'placeholder');
+		Assert::same($s->name, 'image');
+		Assert::same($s->extension, 'jpg');
+
+		// Test that 2-character prefix still works
+		$s = ImageNameScript::fromName('noimage/03/no-image.png');
+
+		Assert::same($s->original, 'noimage/03/no-image.png');
+		Assert::same($s->namespace, 'noimage');
+		Assert::same($s->prefix, '03');
+		Assert::same($s->name, 'no-image');
+		Assert::same($s->extension, 'png');
+	}
+
 }
 
 (new ImageNameScriptTest())->run();


### PR DESCRIPTION
The regex pattern in fromName() required exactly 2 characters for the prefix directory ([^\/]{2}), which caused parsing to fail for noimage paths like "images/noimage/no-image.png".

Changed the pattern to accept prefixes of any length ([^\/]+), allowing users to use flexible noimage_identifier values like the one shown in documentation.

Fixes #43